### PR TITLE
Feature-request (DEV-THOUGHT-01): pass custom tester type, name and scenario params as tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.6.1] - Allow custom tester type, name and scenario parameters
+* Allow addition of custom tester type from other test packages using `@testerType:` tag the value can be like `PatrolIntegrationTester` instead of `WidgetTester`(default) 
+* Allow addition of custom tester name using `@testerName:` tag, the value can be like `$`, `integrationTest` instead of `tester` leaving `tester`(default)
+* Allow passing scenario parameters using `@scenarioParams:` tag, for example: `@scenarioParams: skip: false, timeout: Timeout(Duration(seconds: 1))` and many more. 
+* Though these additions do not affect predefined steps.
 ## [1.6.0] - Change step folder destination
 
 * **BREAKING CHANGE** - Introduce relative and absolute paths for step folder destination

--- a/example/test/sample_test.dart
+++ b/example/test/sample_test.dart
@@ -15,9 +15,11 @@ void main() {
     Future<void> bddSetUp(WidgetTester tester) async {
       await theAppIsRunning(tester);
     }
+
     Future<void> bddTearDown(WidgetTester tester) async {
       await iDoNotSeeText(tester, 'surprise');
     }
+
     testWidgets('''Initial counter value is 0''', (tester) async {
       try {
         await bddSetUp(tester);
@@ -35,7 +37,8 @@ void main() {
         await bddTearDown(tester);
       }
     });
-    testWidgets('''Outline: Plus button increases the counter (0, '0')''', (tester) async {
+    testWidgets('''Outline: Plus button increases the counter (0, '0')''',
+        (tester) async {
       try {
         await bddSetUp(tester);
         await theAppIsRunning(tester);
@@ -45,7 +48,8 @@ void main() {
         await bddTearDown(tester);
       }
     });
-    testWidgets('''Outline: Plus button increases the counter (1, '1')''', (tester) async {
+    testWidgets('''Outline: Plus button increases the counter (1, '1')''',
+        (tester) async {
       try {
         await bddSetUp(tester);
         await theAppIsRunning(tester);
@@ -55,7 +59,8 @@ void main() {
         await bddTearDown(tester);
       }
     });
-    testWidgets('''Outline: Plus button increases the counter (42, '42')''', (tester) async {
+    testWidgets('''Outline: Plus button increases the counter (42, '42')''',
+        (tester) async {
       try {
         await bddSetUp(tester);
         await theAppIsRunning(tester);

--- a/lib/src/feature_file.dart
+++ b/lib/src/feature_file.dart
@@ -14,6 +14,8 @@ class FeatureFile {
   }) : _lines = _prepareLines(
           input.split('\n').map((line) => line.trim()).map(BddLine.new),
         ) {
+    _testerType = parseTesterType(_lines, generatorOptions.testerType);
+
     _stepFiles = _lines
         .where((line) => line.type == LineType.step)
         .map(
@@ -23,12 +25,14 @@ class FeatureFile {
             e.value,
             existingSteps,
             generatorOptions,
+            _testerType,
           ),
         )
         .toList();
   }
 
   late List<StepFile> _stepFiles;
+  late String _testerType;
 
   final String featureDir;
   final String package;
@@ -41,6 +45,7 @@ class FeatureFile {
         _lines,
         getStepFiles(),
         generatorOptions.testMethodName,
+        _testerType,
         isIntegrationTest,
       );
 

--- a/lib/src/feature_file.dart
+++ b/lib/src/feature_file.dart
@@ -2,6 +2,8 @@ import 'package:bdd_widget_test/src/bdd_line.dart';
 import 'package:bdd_widget_test/src/feature_generator.dart';
 import 'package:bdd_widget_test/src/generator_options.dart';
 import 'package:bdd_widget_test/src/step_file.dart';
+import 'package:bdd_widget_test/src/util/common.dart';
+import 'package:bdd_widget_test/src/util/constants.dart';
 
 class FeatureFile {
   FeatureFile({
@@ -14,7 +16,17 @@ class FeatureFile {
   }) : _lines = _prepareLines(
           input.split('\n').map((line) => line.trim()).map(BddLine.new),
         ) {
-    _testerType = parseTesterType(_lines, generatorOptions.testerType);
+    _testerType = parseCustomTagFromFeatureTagLine(
+      _lines,
+      generatorOptions.testerType,
+      testerTypeTag,
+    );
+
+    _testerName = parseCustomTagFromFeatureTagLine(
+      _lines,
+      generatorOptions.testerName,
+      testerNameTag,
+    );
 
     _stepFiles = _lines
         .where((line) => line.type == LineType.step)
@@ -26,6 +38,7 @@ class FeatureFile {
             existingSteps,
             generatorOptions,
             _testerType,
+            _testerName,
           ),
         )
         .toList();
@@ -33,6 +46,7 @@ class FeatureFile {
 
   late List<StepFile> _stepFiles;
   late String _testerType;
+  late String _testerName;
 
   final String featureDir;
   final String package;
@@ -46,6 +60,7 @@ class FeatureFile {
         getStepFiles(),
         generatorOptions.testMethodName,
         _testerType,
+        _testerName,
         isIntegrationTest,
       );
 

--- a/lib/src/feature_generator.dart
+++ b/lib/src/feature_generator.dart
@@ -163,11 +163,16 @@ void _parseFeature(
   for (final scenario in scenarios) {
     final scenarioTagLines =
         scenario.where((line) => line.type == LineType.tag).toList();
-
     final scenarioTestMethodName = parseCustomTagFromFeatureTagLine(
       scenarioTagLines,
       testMethodName,
       testMethodNameTag,
+    );
+
+    final scenarioParams = parseCustomTagFromFeatureTagLine(
+      scenarioTagLines,
+      '',
+      scenarioParamsTag,
     );
 
     final flattenDataTables = replaceDataTables(
@@ -187,9 +192,14 @@ void _parseFeature(
         scenarioTestMethodName,
         testerName,
         scenarioTagLines
-            .where((tag) => !tag.rawLine.startsWith(testMethodNameTag))
+            .where(
+              (tag) =>
+                  !tag.rawLine.startsWith(testMethodNameTag) &&
+                  !tag.rawLine.startsWith(scenarioParamsTag),
+            )
             .map((line) => line.rawLine.substring('@'.length))
             .toList(),
+        scenarioParams,
       );
     }
   }

--- a/lib/src/generator_options.dart
+++ b/lib/src/generator_options.dart
@@ -2,8 +2,9 @@ import 'package:bdd_widget_test/src/util/fs.dart';
 import 'package:bdd_widget_test/src/util/isolate_helper.dart';
 import 'package:yaml/yaml.dart';
 
-const _defaultTestName = 'testWidgets';
+const _defaultTestMethodName = 'testWidgets';
 const _defaultTesterType = 'WidgetTester';
+const _defaultTesterName = 'tester';
 const _stepFolderName = './step';
 
 class GeneratorOptions {
@@ -12,16 +13,19 @@ class GeneratorOptions {
     List<String>? externalSteps,
     String? stepFolderName,
     String? testerType,
+    String? testerName,
     this.include,
   })  : stepFolder = stepFolderName ?? _stepFolderName,
-        testMethodName = testMethodName ?? _defaultTestName,
+        testMethodName = testMethodName ?? _defaultTestMethodName,
         testerType = testerType ?? _defaultTesterType,
+        testerName = testerName ?? _defaultTesterName,
         externalSteps = externalSteps ?? const [];
 
   factory GeneratorOptions.fromMap(Map<String, dynamic> json) =>
       GeneratorOptions(
         testMethodName: json['testMethodName'] as String?,
         testerType: json['testerType'] as String?,
+        testerName: json['testerName'] as String?,
         externalSteps: (json['externalSteps'] as List?)?.cast<String>(),
         stepFolderName: json['stepFolderName'] as String?,
         include: json['include'] is String
@@ -32,6 +36,7 @@ class GeneratorOptions {
   final String stepFolder;
   final String testMethodName;
   final String testerType;
+  final String testerName;
   final List<String>? include;
   final List<String> externalSteps;
 }
@@ -66,6 +71,7 @@ GeneratorOptions readFromUri(Uri uri) {
   return GeneratorOptions(
     testMethodName: doc['testMethodName'] as String?,
     testerType: doc['testerType'] as String?,
+    testerName: doc['testerName'] as String?,
     externalSteps: (doc['externalSteps'] as List?)?.cast<String>(),
     stepFolderName: doc['stepFolderName'] as String?,
     include: doc['include'] is String
@@ -76,11 +82,13 @@ GeneratorOptions readFromUri(Uri uri) {
 
 GeneratorOptions merge(GeneratorOptions a, GeneratorOptions b) =>
     GeneratorOptions(
-      testMethodName: a.testMethodName != _defaultTestName
+      testMethodName: a.testMethodName != _defaultTestMethodName
           ? a.testMethodName
           : b.testMethodName,
       testerType:
           a.testerType != _defaultTesterType ? a.testerType : b.testerType,
+      testerName:
+          a.testerName != _defaultTesterName ? a.testerName : b.testerName,
       stepFolderName:
           a.stepFolder != _stepFolderName ? a.stepFolder : b.stepFolder,
       externalSteps: [...a.externalSteps, ...b.externalSteps],

--- a/lib/src/generator_options.dart
+++ b/lib/src/generator_options.dart
@@ -3,6 +3,7 @@ import 'package:bdd_widget_test/src/util/isolate_helper.dart';
 import 'package:yaml/yaml.dart';
 
 const _defaultTestName = 'testWidgets';
+const _defaultTesterType = 'WidgetTester';
 const _stepFolderName = './step';
 
 class GeneratorOptions {
@@ -10,14 +11,17 @@ class GeneratorOptions {
     String? testMethodName,
     List<String>? externalSteps,
     String? stepFolderName,
+    String? testerType,
     this.include,
   })  : stepFolder = stepFolderName ?? _stepFolderName,
         testMethodName = testMethodName ?? _defaultTestName,
+        testerType = testerType ?? _defaultTesterType,
         externalSteps = externalSteps ?? const [];
 
   factory GeneratorOptions.fromMap(Map<String, dynamic> json) =>
       GeneratorOptions(
         testMethodName: json['testMethodName'] as String?,
+        testerType: json['testerType'] as String?,
         externalSteps: (json['externalSteps'] as List?)?.cast<String>(),
         stepFolderName: json['stepFolderName'] as String?,
         include: json['include'] is String
@@ -27,6 +31,7 @@ class GeneratorOptions {
 
   final String stepFolder;
   final String testMethodName;
+  final String testerType;
   final List<String>? include;
   final List<String> externalSteps;
 }
@@ -60,6 +65,7 @@ GeneratorOptions readFromUri(Uri uri) {
   final doc = loadYamlNode(rawYaml) as YamlMap;
   return GeneratorOptions(
     testMethodName: doc['testMethodName'] as String?,
+    testerType: doc['testerType'] as String?,
     externalSteps: (doc['externalSteps'] as List?)?.cast<String>(),
     stepFolderName: doc['stepFolderName'] as String?,
     include: doc['include'] is String
@@ -73,6 +79,8 @@ GeneratorOptions merge(GeneratorOptions a, GeneratorOptions b) =>
       testMethodName: a.testMethodName != _defaultTestName
           ? a.testMethodName
           : b.testMethodName,
+      testerType:
+          a.testerType != _defaultTesterType ? a.testerType : b.testerType,
       stepFolderName:
           a.stepFolder != _stepFolderName ? a.stepFolder : b.stepFolder,
       externalSteps: [...a.externalSteps, ...b.externalSteps],

--- a/lib/src/scenario_generator.dart
+++ b/lib/src/scenario_generator.dart
@@ -9,26 +9,27 @@ void parseScenario(
   bool hasSetUp,
   bool hasTearDown,
   String testMethodName,
+  String testerName,
   List<String> tags,
 ) {
   sb.writeln(
-    "    $testMethodName('''$scenarioTitle''', (tester) async {",
+    "    $testMethodName('''$scenarioTitle''', ($testerName) async {",
   );
   if (hasTearDown) {
     sb.writeln('      try {');
   }
   final spaces = hasTearDown ? '        ' : '      ';
   if (hasSetUp) {
-    sb.writeln('${spaces}await $setUpMethodName(tester);');
+    sb.writeln('${spaces}await $setUpMethodName($testerName);');
   }
 
   for (final step in scenario) {
-    sb.writeln('${spaces}await ${getStepMethodCall(step.value)};');
+    sb.writeln('${spaces}await ${getStepMethodCall(step.value, testerName)};');
   }
 
   if (hasTearDown) {
     sb.writeln('      } finally {');
-    sb.writeln('        await $tearDownMethodName(tester);');
+    sb.writeln('        await $tearDownMethodName($testerName);');
     sb.writeln('      }');
   }
   sb.writeln(

--- a/lib/src/scenario_generator.dart
+++ b/lib/src/scenario_generator.dart
@@ -11,6 +11,7 @@ void parseScenario(
   String testMethodName,
   String testerName,
   List<String> tags,
+  String scenarioParams,
 ) {
   sb.writeln(
     "    $testMethodName('''$scenarioTitle''', ($testerName) async {",
@@ -33,8 +34,16 @@ void parseScenario(
     sb.writeln('      }');
   }
   sb.writeln(
-    '    }${tags.isNotEmpty ? ", tags: ['${tags.join("', '")}']" : ''});',
+    '    }${tags.isNotEmpty ? ", tags: ['${tags.join("', '")}']" : ''}${scenarioParams.isNotEmpty ? ',' : ');'}',
   );
+  if (scenarioParams.isNotEmpty) {
+    for (final param in scenarioParams.split(', ')) {
+      sb.writeln('     $param,');
+    }
+    sb.writeln(
+      '     );',
+    );
+  }
 }
 
 List<List<BddLine>> generateScenariosFromScenaioOutline(

--- a/lib/src/step/generic_step.dart
+++ b/lib/src/step/generic_step.dart
@@ -7,37 +7,43 @@ class GenericStep implements BddStep {
     this.methodName,
     this.rawLine,
     this.testerType,
+    this.customTesterName,
   );
 
   final String rawLine;
   final String methodName;
   final String testerType;
+  final String customTesterName;
 
   @override
   String get content => '''
 import 'package:flutter_test/flutter_test.dart';
 
-${getStepSignature(rawLine, testerType)} {
+${getStepSignature(rawLine, testerType, customTesterName)} {
   throw UnimplementedError();
 }
 ''';
 
-  String getStepSignature(String stepLine, String testerType) {
+  String getStepSignature(
+    String stepLine,
+    String testerType,
+    String testerName,
+  ) {
     final params = parseRawStepLine(stepLine).skip(1);
     if (params.isEmpty) {
       final examples = examplesRegExp.allMatches(stepLine);
       if (examples.isEmpty) {
-        return 'Future<void> $methodName($testerType tester) async';
+        return 'Future<void> $methodName($testerType $testerName) async';
       } else {
-        return _generateSignature(examples.length, testerType);
+        return _generateSignature(examples.length, testerName);
       }
     }
-    return _generateSignature(params.length, testerType);
+    return _generateSignature(params.length, testerName);
   }
 
-  String _generateSignature(int paramsCount, String testerType) {
+  String _generateSignature(int paramsCount, String testerName) {
     final p = List.generate(paramsCount, (index) => index + 1);
     final methodParameters = p.map((p) => 'dynamic param$p').join(', ');
-    return 'Future<void> $methodName($testerType tester, $methodParameters) async';
+    return 'Future<void> $methodName($testerType $testerName, $methodParameters) async';
   }
 }

--- a/lib/src/step/generic_step.dart
+++ b/lib/src/step/generic_step.dart
@@ -3,36 +3,41 @@ import 'package:bdd_widget_test/src/step/bdd_step.dart';
 import 'package:bdd_widget_test/src/step_generator.dart';
 
 class GenericStep implements BddStep {
-  GenericStep(this.methodName, this.rawLine);
+  GenericStep(
+    this.methodName,
+    this.rawLine,
+    this.testerType,
+  );
 
   final String rawLine;
   final String methodName;
+  final String testerType;
 
   @override
   String get content => '''
 import 'package:flutter_test/flutter_test.dart';
 
-${getStepSignature(rawLine)} {
+${getStepSignature(rawLine, testerType)} {
   throw UnimplementedError();
 }
 ''';
 
-  String getStepSignature(String stepLine) {
+  String getStepSignature(String stepLine, String testerType) {
     final params = parseRawStepLine(stepLine).skip(1);
     if (params.isEmpty) {
       final examples = examplesRegExp.allMatches(stepLine);
       if (examples.isEmpty) {
-        return 'Future<void> $methodName(WidgetTester tester) async';
+        return 'Future<void> $methodName($testerType tester) async';
       } else {
-        return _generateSignature(examples.length);
+        return _generateSignature(examples.length, testerType);
       }
     }
-    return _generateSignature(params.length);
+    return _generateSignature(params.length, testerType);
   }
 
-  String _generateSignature(int paramsCount) {
+  String _generateSignature(int paramsCount, String testerType) {
     final p = List.generate(paramsCount, (index) => index + 1);
     final methodParameters = p.map((p) => 'dynamic param$p').join(', ');
-    return 'Future<void> $methodName(WidgetTester tester, $methodParameters) async';
+    return 'Future<void> $methodName($testerType tester, $methodParameters) async';
   }
 }

--- a/lib/src/step_file.dart
+++ b/lib/src/step_file.dart
@@ -1,6 +1,8 @@
+import 'package:bdd_widget_test/src/bdd_line.dart';
 import 'package:bdd_widget_test/src/generator_options.dart';
 import 'package:bdd_widget_test/src/step_generator.dart';
 import 'package:bdd_widget_test/src/util/constants.dart';
+import 'package:collection/collection.dart';
 import 'package:path/path.dart' as p;
 
 abstract class StepFile {
@@ -13,8 +15,13 @@ abstract class StepFile {
     String line,
     Map<String, String> existingSteps,
     GeneratorOptions generatorOptions,
+    String testerTypeTag,
   ) {
     final file = '${getStepFilename(line)}.dart';
+
+    final testerType = testerTypeTag.isNotEmpty
+        ? parseTesterTypeTag(testerTypeTag)
+        : generatorOptions.testerType;
 
     if (existingSteps.containsKey(file)) {
       final import =
@@ -33,7 +40,7 @@ abstract class StepFile {
       final import =
           p.join(generatorOptions.stepFolder, file).replaceAll(r'\', '/');
       final filename = p.join(featureDir, generatorOptions.stepFolder, file);
-      return NewStepFile._(import, filename, package, line);
+      return NewStepFile._(import, filename, package, line, testerType);
     }
 
     final pathToTestFolder = p.relative(testFolderName, from: featureDir);
@@ -41,19 +48,25 @@ abstract class StepFile {
         .join(pathToTestFolder, generatorOptions.stepFolder, file)
         .replaceAll(r'\', '/');
     final filename = p.join(testFolderName, generatorOptions.stepFolder, file);
-    return NewStepFile._(import, filename, package, line);
+    return NewStepFile._(import, filename, package, line, testerType);
   }
 }
 
 class NewStepFile extends StepFile {
-  const NewStepFile._(super.import, this.filename, this.package, this.line)
-      : super._();
+  const NewStepFile._(
+    super.import,
+    this.filename,
+    this.package,
+    this.line,
+    this.testerType,
+  ) : super._();
 
   final String package;
   final String line;
   final String filename;
+  final String testerType;
 
-  String get dartContent => generateStepDart(package, line);
+  String get dartContent => generateStepDart(package, line, testerType);
 }
 
 class ExistingStepFile extends StepFile {
@@ -62,4 +75,34 @@ class ExistingStepFile extends StepFile {
 
 class ExternalStepFile extends StepFile {
   const ExternalStepFile._(super.import) : super._();
+}
+
+/// [parseTesterType] returns tester type e.g. PatrolTester || WidgetTester (default)
+String parseTesterType(
+  List<BddLine> featureTagLines,
+  String defaultTesterType,
+) {
+  var stepTesterType = defaultTesterType;
+
+  final customTesterTypeTagline = featureTagLines
+      .firstWhereOrNull((line) => line.rawLine.startsWith(testerTypeTag));
+
+  if (customTesterTypeTagline != null) {
+    final testerTypeOverride = parseTesterTypeTag(
+      customTesterTypeTagline.rawLine,
+    );
+    if (testerTypeOverride.isNotEmpty) {
+      stepTesterType = testerTypeOverride;
+    }
+  }
+  return stepTesterType;
+}
+
+/// [parseTesterTypeTag] Returns tester type or empty string if not found.
+/// Example: @testerTypeTag returns PatrolTester || WidgetTester (default)
+String parseTesterTypeTag(String rawLine) {
+  if (rawLine.startsWith(testerTypeTag)) {
+    return rawLine.substring(testerTypeTag.length).trim();
+  }
+  return '';
 }

--- a/lib/src/step_generator.dart
+++ b/lib/src/step_generator.dart
@@ -33,19 +33,29 @@ String getStepMethodName(String stepText) {
   return _camelizedString(step);
 }
 
-String getStepMethodCall(String stepLine, {List<String>? forceParams}) {
+String getStepMethodCall(
+  String stepLine,
+  String customTesterName, {
+  List<String>? forceParams,
+}) {
   final step = parseRawStepLine(stepLine);
   final parameters = [
-    'tester',
+    customTesterName,
     if (forceParams != null) ...forceParams else ...step.skip(1)
   ].join(', ');
   return '${_camelizedString(step[0])}($parameters)';
 }
 
-String generateStepDart(String package, String line, String testerType) {
+String generateStepDart(
+  String package,
+  String line,
+  String testerType,
+  String customTesterName,
+) {
   final methodName = getStepMethodName(line);
 
-  final bddStep = _getStep(methodName, package, line, testerType);
+  final bddStep =
+      _getStep(methodName, package, line, testerType, customTesterName);
   return bddStep.content;
 }
 
@@ -54,10 +64,11 @@ BddStep _getStep(
   String package,
   String line,
   String testerType,
+  String testerName,
 ) {
   //for now, predefined steps don't support testerType
   final factory = predefinedSteps[methodName] ??
-      (_, __) => GenericStep(methodName, line, testerType);
+      (_, __) => GenericStep(methodName, line, testerType, testerName);
   return factory(package, line);
 }
 

--- a/lib/src/step_generator.dart
+++ b/lib/src/step_generator.dart
@@ -42,15 +42,22 @@ String getStepMethodCall(String stepLine, {List<String>? forceParams}) {
   return '${_camelizedString(step[0])}($parameters)';
 }
 
-String generateStepDart(String package, String line) {
+String generateStepDart(String package, String line, String testerType) {
   final methodName = getStepMethodName(line);
-  final bddStep = _getStep(methodName, package, line);
+
+  final bddStep = _getStep(methodName, package, line, testerType);
   return bddStep.content;
 }
 
-BddStep _getStep(String methodName, String package, String line) {
-  final factory =
-      predefinedSteps[methodName] ?? (_, __) => GenericStep(methodName, line);
+BddStep _getStep(
+  String methodName,
+  String package,
+  String line,
+  String testerType,
+) {
+  //for now, predefined steps don't support testerType
+  final factory = predefinedSteps[methodName] ??
+      (_, __) => GenericStep(methodName, line, testerType);
   return factory(package, line);
 }
 

--- a/lib/src/util/common.dart
+++ b/lib/src/util/common.dart
@@ -1,0 +1,34 @@
+import 'package:bdd_widget_test/src/bdd_line.dart';
+import 'package:collection/collection.dart';
+
+/// [parseCustomTag] Returns custom tag value or empty string if not found.
+/// Example: @testerTypeTag: PatrolTester returns `PatrolTester`
+String parseCustomTag(String rawLine, String customTag) {
+  if (rawLine.startsWith(customTag)) {
+    return rawLine.substring(customTag.length).trim();
+  }
+  return '';
+}
+
+/// [parseCustomTagFromFeatureTagLine] returns tags of [customTag] from the feature tag lines
+String parseCustomTagFromFeatureTagLine(
+  List<BddLine> featureTagLines,
+  String defaultTagValue,
+  String customTag,
+) {
+  var tagType = defaultTagValue;
+
+  final customTagLine = featureTagLines
+      .firstWhereOrNull((line) => line.rawLine.startsWith(customTag));
+
+  if (customTagLine != null) {
+    final tagOverride = parseCustomTag(
+      customTagLine.rawLine,
+      customTag,
+    );
+    if (tagOverride.isNotEmpty) {
+      tagType = tagOverride;
+    }
+  }
+  return tagType;
+}

--- a/lib/src/util/constants.dart
+++ b/lib/src/util/constants.dart
@@ -3,4 +3,8 @@ const tearDownMethodName = 'bddTearDown';
 
 const testMethodNameTag = '@testMethodName:';
 
+/// The tag to specify the tester type to use for the test.
+/// The default testerTypeTag value is `WidgetTester`.
+const testerTypeTag = '@testerType:';
+
 const testFolderName = 'test';

--- a/lib/src/util/constants.dart
+++ b/lib/src/util/constants.dart
@@ -3,8 +3,11 @@ const tearDownMethodName = 'bddTearDown';
 
 const testMethodNameTag = '@testMethodName:';
 
-/// The tag to specify the tester type to use for the test.
+/// [testerTypeTag] to specify the tester type to use for the test.
 /// The default testerTypeTag value is `WidgetTester`.
 const testerTypeTag = '@testerType:';
+
+/// [testerNameTag] specifies the tester name to use, the default value is tester
+const testerNameTag = '@testerName:';
 
 const testFolderName = 'test';

--- a/lib/src/util/constants.dart
+++ b/lib/src/util/constants.dart
@@ -5,9 +5,16 @@ const testMethodNameTag = '@testMethodName:';
 
 /// [testerTypeTag] to specify the tester type to use for the test.
 /// The default testerTypeTag value is `WidgetTester`.
+/// should be on the top level of a feature file or inside build.yaml options
 const testerTypeTag = '@testerType:';
 
 /// [testerNameTag] specifies the tester name to use, the default value is tester
+/// should be on the top level of a feature file or inside build.yaml options
 const testerNameTag = '@testerName:';
+
+/// [scenarioParamsTag] can be used to filter custom parameters for
+/// scenario functions for example: @scenarioParams: skip: false, timeout: Timeout(Duration(seconds: 1))
+/// because some test packaages like `patrol` support this.
+const scenarioParamsTag = '@scenarioParams:';
 
 const testFolderName = 'test';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bdd_widget_test
 description: A BDD-style widget testing library. Generates Flutter widget tests from *.feature files.
-version: 1.6.0
+version: 1.6.1
 homepage: https://github.com/olexale/bdd_widget_test
 
 environment:

--- a/test/custom_scenario_params_test.dart
+++ b/test/custom_scenario_params_test.dart
@@ -1,0 +1,46 @@
+import 'package:bdd_widget_test/src/feature_file.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('Feature Custom Scenario Parameters using tag only', () {
+    const featureFile = '''
+Feature: Testing feature 
+  @scenarioParams: skip: false, timeout: Timeout(Duration(seconds: 1))
+  Scenario: Testing scenario
+    Given the app is running with patrol
+
+''';
+
+    const expectedFeatureDart = '''
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: unused_import, directives_ordering
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import './step/the_app_is_running_with_patrol.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  group(\'\'\'Testing feature\'\'\', () {
+    testWidgets(\'\'\'Testing scenario\'\'\', (tester) async {
+      await theAppIsRunningWithPatrol(tester);
+    },
+     skip: false,
+     timeout: Timeout(Duration(seconds: 1)),
+     );
+  });
+}
+''';
+
+    final feature = FeatureFile(
+      featureDir: 'test.feature',
+      package: 'test',
+      input: featureFile,
+      isIntegrationTest: true,
+    );
+    expect(feature.dartContent, expectedFeatureDart);
+  });
+}

--- a/test/custom_tester_name_test.dart
+++ b/test/custom_tester_name_test.dart
@@ -1,0 +1,82 @@
+import 'package:bdd_widget_test/src/feature_file.dart';
+import 'package:bdd_widget_test/src/generator_options.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('Feature Custom Tester name using tag', () {
+    const featureFile = '''
+@testerName: helloTester
+Feature: Testing feature 
+  Scenario: Testing scenario
+    Given the app is running with patrol
+
+''';
+
+    const expectedFeatureDart = '''
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: unused_import, directives_ordering
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import './step/the_app_is_running_with_patrol.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  group(\'\'\'Testing feature\'\'\', () {
+    testWidgets(\'\'\'Testing scenario\'\'\', (helloTester) async {
+      await theAppIsRunningWithPatrol(helloTester);
+    });
+  });
+}
+''';
+
+    final feature = FeatureFile(
+      featureDir: 'test.feature',
+      package: 'test',
+      input: featureFile,
+      isIntegrationTest: true,
+    );
+    expect(feature.dartContent, expectedFeatureDart);
+  });
+  test('Feature Custom Tester name using generator options', () {
+    const featureFile = '''
+Feature: Testing feature 
+  Scenario: Testing scenario
+    Given the app is running with patrol
+
+''';
+
+    const expectedFeatureDart = '''
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: unused_import, directives_ordering
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import './step/the_app_is_running_with_patrol.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  group(\'\'\'Testing feature\'\'\', () {
+    testWidgets(\'\'\'Testing scenario\'\'\', (helloTester) async {
+      await theAppIsRunningWithPatrol(helloTester);
+    });
+  });
+}
+''';
+
+    final feature = FeatureFile(
+      featureDir: 'test.feature',
+      package: 'test',
+      input: featureFile,
+      isIntegrationTest: true,
+      generatorOptions: const GeneratorOptions(testerName: 'helloTester'),
+    );
+    expect(feature.dartContent, expectedFeatureDart);
+  });
+}

--- a/test/custom_tester_type_test.dart
+++ b/test/custom_tester_type_test.dart
@@ -1,0 +1,83 @@
+import 'package:bdd_widget_test/src/feature_file.dart';
+import 'package:bdd_widget_test/src/generator_options.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('Feature Custom Tester Type using tag', () {
+    const featureFile = '''
+@testerType: PatrolIntegrationTester
+Feature: Testing feature 
+  Scenario: Testing scenario
+    Given the app is running with patrol
+
+''';
+
+    const expectedFeatureDart = '''
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: unused_import, directives_ordering
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import './step/the_app_is_running_with_patrol.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  group(\'\'\'Testing feature\'\'\', () {
+    testWidgets(\'\'\'Testing scenario\'\'\', (tester) async {
+      await theAppIsRunningWithPatrol(tester);
+    });
+  });
+}
+''';
+
+    final feature = FeatureFile(
+      featureDir: 'test.feature',
+      package: 'test',
+      input: featureFile,
+      isIntegrationTest: true,
+    );
+    expect(feature.dartContent, expectedFeatureDart);
+  });
+
+  test('Feature Custom Tester Type using generator options', () {
+    const featureFile = '''
+Feature: Testing feature 
+  Scenario: Testing scenario
+    Given the app is running with patrol
+
+''';
+
+    const expectedFeatureDart = '''
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: unused_import, directives_ordering
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import './step/the_app_is_running_with_patrol.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  group(\'\'\'Testing feature\'\'\', () {
+    testWidgets(\'\'\'Testing scenario\'\'\', (tester) async {
+      await theAppIsRunningWithPatrol(tester);
+    });
+  });
+}
+''';
+
+    final feature = FeatureFile(
+      featureDir: 'test.feature',
+      package: 'test',
+      input: featureFile,
+      isIntegrationTest: true,
+      generatorOptions: const GeneratorOptions(testerType: 'PatrolIntegrationTester'),
+    );
+    expect(feature.dartContent, expectedFeatureDart);
+  });
+}

--- a/test/custom_tester_type_test.dart
+++ b/test/custom_tester_type_test.dart
@@ -76,7 +76,8 @@ void main() {
       package: 'test',
       input: featureFile,
       isIntegrationTest: true,
-      generatorOptions: const GeneratorOptions(testerType: 'PatrolIntegrationTester'),
+      generatorOptions:
+          const GeneratorOptions(testerType: 'PatrolIntegrationTester'),
     );
     expect(feature.dartContent, expectedFeatureDart);
   });


### PR DESCRIPTION
## [1.6.1] - Allow custom tester type, name and scenario parameters
* Allow addition of custom tester type from other test packages using `@testerType:` tag the value can be like `PatrolIntegrationTester` instead of `WidgetTester`(default) 
* Allow addition of custom tester name using `@testerName:` tag, the value can be like `$`, `integrationTest` instead of `tester` leaving `tester`(default)
* Allow passing scenario parameters using `@scenarioParams:` tag, for example: `@scenarioParams: skip: false, timeout: Timeout(Duration(seconds: 1))` and many more. 
* Though these additions do not affect predefined steps.