### PR TITLE
Feature-request: (DEV-THOUGHT-02): temporarily-remove-feature-grouping

### DIFF
--- a/lib/src/feature_generator.dart
+++ b/lib/src/feature_generator.dart
@@ -72,8 +72,6 @@ String generateFeatureDart(
   );
 
   for (final feature in features) {
-    sb.writeln("  group('''${feature.first.value}''', () {");
-
     final hasBackground = _parseBackground(
       sb,
       feature,
@@ -203,7 +201,6 @@ void _parseFeature(
       );
     }
   }
-  sb.writeln('  });');
 }
 
 bool _isNewScenario(LineType type) =>


### PR DESCRIPTION
- I temporarily remove the dart `group()` feature in a test file as a workaround pending this https://github.com/leancodepl/patrol/issues/1619 to be resolved. 

